### PR TITLE
Improve auth flow and navigation

### DIFF
--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/frontend/src/AppNavigator.tsx
+++ b/frontend/src/AppNavigator.tsx
@@ -1,17 +1,37 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import LoginScreen from './screens/LoginScreen';
 import SignupScreen from './screens/SignupScreen';
 import FeedScreen from './screens/FeedScreen';
+import AskDoubtScreen from './screens/AskDoubtScreen';
+import ChatScreen from './screens/ChatScreen';
+import ProfileScreen from './screens/ProfileScreen';
+import LeaderboardScreen from './screens/LeaderboardScreen';
+import StoryViewer from './screens/StoryViewer';
+import AuthContext from './context/AuthContext';
 
 const Stack = createNativeStackNavigator();
 
 export default function AppNavigator() {
+  const { token } = useContext(AuthContext);
+
   return (
-    <Stack.Navigator initialRouteName="Login">
-      <Stack.Screen name="Login" component={LoginScreen} />
-      <Stack.Screen name="Signup" component={SignupScreen} />
-      <Stack.Screen name="Feed" component={FeedScreen} />
-    </Stack.Navigator>
-  );
+    <Stack.Navigator>
+      {token ? (
+        <>
+          <Stack.Screen name="Feed" component={FeedScreen} />
+          <Stack.Screen name="AskDoubt" component={AskDoubtScreen} />
+          <Stack.Screen name="Chat" component={ChatScreen} />
+          <Stack.Screen name="Profile" component={ProfileScreen} />
+          <Stack.Screen name="Leaderboard" component={LeaderboardScreen} />
+          <Stack.Screen name="StoryViewer" component={StoryViewer} />
+        </>
+      ) : (
+        <>
+          <Stack.Screen name="Login" component={LoginScreen} />
+          <Stack.Screen name="Signup" component={SignupScreen} />
+        </>
+      )}
+      </Stack.Navigator>
+    );
 }

--- a/frontend/src/screens/LoginScreen.tsx
+++ b/frontend/src/screens/LoginScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext } from 'react';
-import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { View, TextInput, Button, StyleSheet, Alert } from 'react-native';
 import AuthContext from '../context/AuthContext';
 
 export default function LoginScreen({ navigation }: any) {
@@ -8,8 +8,12 @@ export default function LoginScreen({ navigation }: any) {
   const [password, setPassword] = useState('');
 
   const handleLogin = async () => {
-    await login(email, password);
-    navigation.replace('Feed');
+    const ok = await login(email, password);
+    if (ok) {
+      navigation.reset({ index: 0, routes: [{ name: 'Feed' }] });
+    } else {
+      Alert.alert('Login failed', 'Invalid email or password');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- connect context to API helpers and add error handling
- show an alert if login fails
- use token in `AppNavigator` to switch between auth and app screens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a823c2f1c832199679d6b27f18c08