### PR TITLE
Add web dependencies for Expo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .env
 dev.db
 uploads/
+frontend/node_modules/

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import AppNavigator from './src/AppNavigator';
+import { AuthProvider } from './src/context/AuthContext';
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <NavigationContainer>
+        <AppNavigator />
+      </NavigationContainer>
+    </AuthProvider>
+  );
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "growth-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.1",
+    "react-native-web": "~0.19.6",
+    "react-dom": "18.2.0",
+    "@expo/metro-runtime": "~3.1.3",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12",
+    "@react-navigation/bottom-tabs": "^6.5.20",
+    "axios": "^1.6.8",
+    "jwt-decode": "^3.1.2",
+    "expo-secure-store": "^12.1.1"
+  }
+}

--- a/frontend/src/AppNavigator.tsx
+++ b/frontend/src/AppNavigator.tsx
@@ -1,0 +1,49 @@
+import React, { useContext } from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import LoginScreen from './screens/LoginScreen';
+import SignupScreen from './screens/SignupScreen';
+import SchoolSignupScreen from './screens/SchoolSignupScreen';
+import FeedScreen from './screens/FeedScreen';
+import AskDoubtScreen from './screens/AskDoubtScreen';
+import ProfileScreen from './screens/ProfileScreen';
+import LeaderboardScreen from './screens/LeaderboardScreen';
+import StoryViewer from './screens/StoryViewer';
+import ChatScreen from './screens/ChatScreen';
+import AuthContext from './context/AuthContext';
+
+const Stack = createNativeStackNavigator();
+const Tab = createBottomTabNavigator();
+
+function MainTabs() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen name="Feed" component={FeedScreen} />
+      <Tab.Screen name="Doubt" component={AskDoubtScreen} />
+      <Tab.Screen name="Profile" component={ProfileScreen} />
+    </Tab.Navigator>
+  );
+}
+
+export default function AppNavigator() {
+  const { token } = useContext(AuthContext);
+
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      {token ? (
+        <>
+          <Stack.Screen name="Main" component={MainTabs} />
+          <Stack.Screen name="Leaderboard" component={LeaderboardScreen} />
+          <Stack.Screen name="Stories" component={StoryViewer} />
+          <Stack.Screen name="Chat" component={ChatScreen} />
+        </>
+      ) : (
+        <>
+          <Stack.Screen name="Login" component={LoginScreen} />
+          <Stack.Screen name="Signup" component={SignupScreen} />
+          <Stack.Screen name="SchoolSignup" component={SchoolSignupScreen} />
+        </>
+      )}
+    </Stack.Navigator>
+  );
+}

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,16 @@
+import api from './client';
+
+export async function signup(data: {
+  name: string;
+  email: string;
+  password: string;
+  grade: string;
+  school_code: string;
+}) {
+  await api.post('/auth/signup', data);
+}
+
+export async function login(email: string, password: string) {
+  const res = await api.post('/auth/login', { email, password });
+  return res.data.access_token as string;
+}

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -1,0 +1,14 @@
+import api from './client';
+
+export async function sendMessage(
+  senderId: number,
+  receiverId: number,
+  message: string
+) {
+  await api.post('/chat/send', { sender_id: senderId, receiver_id: receiverId, message });
+}
+
+export async function fetchChatHistory(user1: number, user2: number) {
+  const res = await api.get(`/chat/history/${user1}/${user2}`);
+  return res.data;
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+export const API_URL = 'http://localhost:8000';
+
+const api = axios.create({ baseURL: API_URL });
+
+export default api;

--- a/frontend/src/api/doubt.ts
+++ b/frontend/src/api/doubt.ts
@@ -1,0 +1,10 @@
+import api from './client';
+
+export async function askDoubt(token: string, question: string) {
+  const res = await api.post(
+    '/doubt/ask',
+    { question },
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  return res.data;
+}

--- a/frontend/src/api/feed.ts
+++ b/frontend/src/api/feed.ts
@@ -1,0 +1,27 @@
+import api from './client';
+
+export async function uploadImage(userId: number, caption: string, uri: string) {
+  const form = new FormData();
+  form.append('user_id', String(userId));
+  form.append('caption', caption);
+  // @ts-ignore
+  form.append('image', { uri, name: 'image.jpg', type: 'image/jpeg' });
+
+  const res = await api.post('/feed/upload-image', form, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+  return res.data;
+}
+
+export async function fetchPosts(userId: number) {
+  const res = await api.get('/feed/all', { params: { user_id: userId } });
+  return res.data.posts as any[];
+}
+
+export async function reactToPost(postId: number, userId: number, emoji: string) {
+  await api.post('/feed/react', { post_id: postId, user_id: userId, emoji });
+}
+
+export async function commentOnPost(postId: number, userId: number, comment: string) {
+  await api.post('/feed/comment', { post_id: postId, user_id: userId, comment });
+}

--- a/frontend/src/api/leaderboard.ts
+++ b/frontend/src/api/leaderboard.ts
@@ -1,0 +1,6 @@
+import api from './client';
+
+export async function fetchLeaderboard(schoolId: number) {
+  const res = await api.get(`/leaderboard/leaderboard/${schoolId}`);
+  return res.data;
+}

--- a/frontend/src/api/school.ts
+++ b/frontend/src/api/school.ts
@@ -1,0 +1,5 @@
+import api from './client';
+
+export async function createSchool(name: string, code: string) {
+  await api.post('/school/create', { name, code });
+}

--- a/frontend/src/api/story.ts
+++ b/frontend/src/api/story.ts
@@ -1,0 +1,17 @@
+import api from './client';
+
+export async function postStory(token: string, data: FormData) {
+  const res = await api.post('/story/post', data, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+  return res.data;
+}
+
+export async function fetchAllStories() {
+  const res = await api.get('/story/active/all');
+  const obj = res.data.active_stories as Record<string, any[]>;
+  return Object.keys(obj).map((user) => ({ user, stories: obj[user] }));
+}

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -1,0 +1,18 @@
+import api from './client';
+
+export async function getMe(token: string) {
+  const res = await api.get('/user/me', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return res.data;
+}
+
+export async function uploadAvatar(token: string, fileUri: string) {
+  const form = new FormData();
+  // @ts-ignore
+  form.append('file', { uri: fileUri, name: 'avatar.jpg', type: 'image/jpeg' });
+  const res = await api.post('/user/upload-avatar', form, {
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'multipart/form-data' },
+  });
+  return res.data;
+}

--- a/frontend/src/components/ChatBubble.tsx
+++ b/frontend/src/components/ChatBubble.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+interface Props {
+  message: string;
+  isMe: boolean;
+}
+
+export default function ChatBubble({ message, isMe }: Props) {
+  return (
+    <View style={[styles.bubble, isMe ? styles.me : styles.them]}>
+      <Text style={styles.text}>{message}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bubble: {
+    padding: 10,
+    borderRadius: 8,
+    marginVertical: 4,
+    maxWidth: '70%',
+  },
+  me: {
+    backgroundColor: '#dcf8c6',
+    alignSelf: 'flex-end',
+  },
+  them: {
+    backgroundColor: '#f0f0f0',
+    alignSelf: 'flex-start',
+  },
+  text: { fontSize: 16 },
+});

--- a/frontend/src/components/FeedCard.tsx
+++ b/frontend/src/components/FeedCard.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { View, Text, Image, StyleSheet } from 'react-native';
+
+interface Props {
+  caption: string;
+  imageUrl: string;
+  timestamp?: string;
+}
+
+export default function FeedCard({ caption, imageUrl, timestamp }: Props) {
+  return (
+    <View style={styles.card}>
+      <Image source={{ uri: imageUrl }} style={styles.image} />
+      {timestamp && (
+        <Text style={styles.time}>{new Date(timestamp).toLocaleString()}</Text>
+      )}
+      <Text style={styles.caption}>{caption}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: { marginBottom: 16 },
+  image: { width: '100%', height: 200 },
+  time: { marginTop: 4, color: '#666' },
+  caption: { marginTop: 8, fontSize: 16 },
+});

--- a/frontend/src/components/StoryCircle.tsx
+++ b/frontend/src/components/StoryCircle.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, Image, StyleSheet } from 'react-native';
+
+interface Props {
+  avatarUrl: string;
+}
+
+export default function StoryCircle({ avatarUrl }: Props) {
+  return (
+    <View style={styles.circle}>
+      <Image source={{ uri: avatarUrl }} style={styles.avatar} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  circle: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    overflow: 'hidden',
+    marginHorizontal: 8,
+  },
+  avatar: { width: '100%', height: '100%' },
+});

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,79 @@
+import React, { createContext, useState, ReactNode, useEffect } from 'react';
+import * as SecureStore from 'expo-secure-store';
+import jwtDecode from 'jwt-decode';
+
+interface AuthContextProps {
+  token: string | null;
+  userId: number | null;
+  login: (email: string, password: string) => Promise<void>;
+  signup: (data: SignupData) => Promise<void>;
+  logout: () => void;
+}
+
+interface SignupData {
+  name: string;
+  email: string;
+  password: string;
+  grade: string;
+  school_code: string;
+}
+
+const AuthContext = createContext<AuthContextProps>({
+  token: null,
+  userId: null,
+  login: async () => {},
+  signup: async () => {},
+  logout: () => {},
+});
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [token, setToken] = useState<string | null>(null);
+  const [userId, setUserId] = useState<number | null>(null);
+
+  useEffect(() => {
+    const loadToken = async () => {
+      const stored = await SecureStore.getItemAsync('token');
+      if (stored) {
+        setToken(stored);
+        const decoded: any = jwtDecode(stored);
+        setUserId(decoded.user_id);
+      }
+    };
+    loadToken();
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    const res = await fetch('http://localhost:8000/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    const data = await res.json();
+    setToken(data.access_token);
+    await SecureStore.setItemAsync('token', data.access_token);
+    const decoded: any = jwtDecode(data.access_token);
+    setUserId(decoded.user_id);
+  };
+
+  const signup = async (data: SignupData) => {
+    await fetch('http://localhost:8000/auth/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+  };
+
+  const logout = async () => {
+    setToken(null);
+    setUserId(null);
+    await SecureStore.deleteItemAsync('token');
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, userId, login, signup, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export default AuthContext;

--- a/frontend/src/screens/AskDoubtScreen.tsx
+++ b/frontend/src/screens/AskDoubtScreen.tsx
@@ -1,0 +1,39 @@
+import React, { useState, useContext } from 'react';
+import { View, TextInput, Button, Text, StyleSheet } from 'react-native';
+import AuthContext from '../context/AuthContext';
+import { askDoubt } from '../api/doubt';
+
+export default function AskDoubtScreen() {
+  const { token } = useContext(AuthContext);
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState('');
+
+  const handleAsk = async () => {
+    if (!token) return;
+    const data = await askDoubt(token, question);
+    setAnswer(data.answer);
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        placeholder="Ask a question"
+        value={question}
+        onChangeText={setQuestion}
+        style={styles.input}
+      />
+      <Button title="Ask" onPress={handleAsk} />
+      <Text>{answer}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+  },
+});

--- a/frontend/src/screens/ChatScreen.tsx
+++ b/frontend/src/screens/ChatScreen.tsx
@@ -1,0 +1,39 @@
+import React, { useState, useEffect } from 'react';
+import { View, TextInput, Button, FlatList } from 'react-native';
+import ChatBubble from '../components/ChatBubble';
+import { fetchChatHistory, sendMessage } from '../api/chat';
+
+export default function ChatScreen({ route }: any) {
+  const { user1, user2 } = route.params;
+  const [messages, setMessages] = useState<any[]>([]);
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetchChatHistory(user1, user2);
+      setMessages(res);
+    };
+    load();
+  }, [user1, user2]);
+
+  const send = async () => {
+    await sendMessage(user1, user2, text);
+    setText('');
+    const res = await fetchChatHistory(user1, user2);
+    setMessages(res);
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <FlatList
+        data={messages}
+        keyExtractor={(item) => item.id.toString()}
+        renderItem={({ item }) => (
+          <ChatBubble message={item.message} isMe={item.sender_id === user1} />
+        )}
+      />
+      <TextInput value={text} onChangeText={setText} style={{ borderWidth: 1 }} />
+      <Button title="Send" onPress={send} />
+    </View>
+  );
+}

--- a/frontend/src/screens/FeedScreen.tsx
+++ b/frontend/src/screens/FeedScreen.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState, useContext } from 'react';
+import { View, FlatList } from 'react-native';
+import AuthContext from '../context/AuthContext';
+import { fetchPosts } from '../api/feed';
+import FeedCard from '../components/FeedCard';
+
+export default function FeedScreen() {
+  const { userId } = useContext(AuthContext);
+  const [posts, setPosts] = useState<any[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!userId) return;
+      const data = await fetchPosts(userId);
+      setPosts(data);
+    };
+    load();
+  }, [userId]);
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <FlatList
+        data={posts}
+        keyExtractor={(item) => item.post_id.toString()}
+        renderItem={({ item }) => (
+          <FeedCard
+            caption={item.caption}
+            imageUrl={item.image_url}
+            timestamp={item.created_at}
+          />
+        )}
+      />
+    </View>
+  );
+}

--- a/frontend/src/screens/LeaderboardScreen.tsx
+++ b/frontend/src/screens/LeaderboardScreen.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList } from 'react-native';
+import { fetchLeaderboard } from '../api/leaderboard';
+
+export default function LeaderboardScreen({ route }: any) {
+  const { schoolId } = route.params;
+  const [data, setData] = useState<any>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetchLeaderboard(schoolId);
+      setData(res);
+    };
+    load();
+  }, [schoolId]);
+
+  if (!data) return null;
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text style={{ fontSize: 20, marginBottom: 12 }}>Top Contributors</Text>
+      <FlatList
+        data={data.top_contributors}
+        keyExtractor={(item) => item.user_id.toString()}
+        renderItem={({ item }) => (
+          <Text>{item.name} - Posts: {item.post_count}</Text>
+        )}
+      />
+    </View>
+  );
+}

--- a/frontend/src/screens/LoginScreen.tsx
+++ b/frontend/src/screens/LoginScreen.tsx
@@ -1,0 +1,39 @@
+import React, { useState, useContext } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import AuthContext from '../context/AuthContext';
+
+export default function LoginScreen({ navigation }: any) {
+  const { login } = useContext(AuthContext);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleLogin = async () => {
+    await login(email, password);
+    navigation.replace('Feed');
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput placeholder="Email" value={email} onChangeText={setEmail} style={styles.input} />
+      <TextInput
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        style={styles.input}
+      />
+      <Button title="Login" onPress={handleLogin} />
+      <Button title="Go to Signup" onPress={() => navigation.navigate('Signup')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+  },
+});

--- a/frontend/src/screens/ProfileScreen.tsx
+++ b/frontend/src/screens/ProfileScreen.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState, useContext } from 'react';
+import { View, Text, Image, StyleSheet } from 'react-native';
+import AuthContext from '../context/AuthContext';
+import { getMe } from '../api/user';
+
+export default function ProfileScreen() {
+  const { token } = useContext(AuthContext);
+  const [profile, setProfile] = useState<any>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!token) return;
+      const data = await getMe(token);
+      setProfile(data);
+    };
+    load();
+  }, [token]);
+
+  if (!profile) return null;
+
+  return (
+    <View style={styles.container}>
+      <Image source={{ uri: profile.avatar_url }} style={styles.avatar} />
+      <Text style={styles.name}>{profile.name}</Text>
+      <Text>{profile.email}</Text>
+      <Text>XP: {profile.xp}</Text>
+      <Text>Streak: {profile.streak}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', padding: 16 },
+  avatar: { width: 120, height: 120, borderRadius: 60, marginBottom: 16 },
+  name: { fontSize: 24, fontWeight: 'bold' },
+});

--- a/frontend/src/screens/SchoolSignupScreen.tsx
+++ b/frontend/src/screens/SchoolSignupScreen.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { createSchool } from '../api/school';
+
+export default function SchoolSignupScreen() {
+  const [name, setName] = useState('');
+  const [code, setCode] = useState('');
+
+  const handleCreate = async () => {
+    await createSchool(name, code);
+    setName('');
+    setCode('');
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput placeholder="School Name" value={name} onChangeText={setName} style={styles.input} />
+      <TextInput placeholder="School Code" value={code} onChangeText={setCode} style={styles.input} />
+      <Button title="Create" onPress={handleCreate} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  input: { borderWidth: 1, borderColor: '#ccc', padding: 8, marginBottom: 12 },
+});

--- a/frontend/src/screens/SignupScreen.tsx
+++ b/frontend/src/screens/SignupScreen.tsx
@@ -1,0 +1,44 @@
+import React, { useState, useContext } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import AuthContext from '../context/AuthContext';
+
+export default function SignupScreen({ navigation }: any) {
+  const { signup } = useContext(AuthContext);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [grade, setGrade] = useState('');
+  const [code, setCode] = useState('');
+
+  const handleSignup = async () => {
+    await signup({ name, email, password, grade, school_code: code });
+    navigation.goBack();
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput placeholder="Name" value={name} onChangeText={setName} style={styles.input} />
+      <TextInput placeholder="Email" value={email} onChangeText={setEmail} style={styles.input} />
+      <TextInput
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        style={styles.input}
+      />
+      <TextInput placeholder="Grade" value={grade} onChangeText={setGrade} style={styles.input} />
+      <TextInput placeholder="School Code" value={code} onChangeText={setCode} style={styles.input} />
+      <Button title="Signup" onPress={handleSignup} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+  },
+});

--- a/frontend/src/screens/StoryViewer.tsx
+++ b/frontend/src/screens/StoryViewer.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import { View, FlatList, Text } from 'react-native';
+import { fetchAllStories } from '../api/story';
+import StoryCircle from '../components/StoryCircle';
+
+export default function StoryViewer() {
+  const [stories, setStories] = useState<any[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const data = await fetchAllStories();
+      setStories(data);
+    };
+    load();
+  }, []);
+
+  return (
+    <View style={{ padding: 16 }}>
+      <FlatList
+        horizontal
+        data={stories}
+        keyExtractor={(item) => item.user}
+        renderItem={({ item }) => (
+          <View style={{ alignItems: 'center' }}>
+            <StoryCircle avatarUrl={''} />
+            <Text>{item.user}</Text>
+          </View>
+        )}
+      />
+    </View>
+  );
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ESNext",
+    "jsx": "react",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "lib": ["ES6", "DOM"],
+    "types": ["expo"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.tsx", "src/**/*.ts", "App.tsx"]
+}


### PR DESCRIPTION
## Summary
- include react-native-web, react-dom and @expo/metro-runtime in Expo project
- expand Expo frontend with chat, stories, profile, and leaderboard navigation
- add API wrappers and screens for school signup and user profile

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a73da74548321a18089457e0aa06a