### PR TITLE
Fix route prefix duplication

### DIFF
--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -7,7 +7,7 @@ from app.database import get_db
 
 router = APIRouter()
 
-@router.post("/chat/send")
+@router.post("/send")
 def send_message(sender_id: int, receiver_id: int, content: str, db: Session = Depends(get_db)):
     sender = db.query(User).filter(User.id == sender_id).first()
     receiver = db.query(User).filter(User.id == receiver_id).first()
@@ -31,7 +31,7 @@ def send_message(sender_id: int, receiver_id: int, content: str, db: Session = D
 
     return {"message": "Message sent", "id": message.id}
 
-@router.get("/chat/history/{user1_id}/{user2_id}")
+@router.get("/history/{user1_id}/{user2_id}")
 def get_chat_history(user1_id: int, user2_id: int, db: Session = Depends(get_db)):
     messages = db.query(DirectMessage).filter(
         ((DirectMessage.sender_id == user1_id) & (DirectMessage.receiver_id == user2_id)) |

--- a/app/routes/leaderboard.py
+++ b/app/routes/leaderboard.py
@@ -11,7 +11,7 @@ from app.models.story import Story
 router = APIRouter()
 
 
-@router.get("/leaderboard/{school_id}")
+@router.get("/{school_id}")
 def get_full_leaderboard(school_id: int, db: Session = Depends(get_db)):
     try:
         users = db.query(User).filter(User.school_id == school_id).all()

--- a/app/routes/school.py
+++ b/app/routes/school.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from app.database import SessionLocal
 from app.models.user import School
 
-router = APIRouter(prefix="/school", tags=["School"])
+router = APIRouter(tags=["School"])
 
 @router.post("/create")
 def create_school(data: dict):


### PR DESCRIPTION
## Summary
- correct chat route paths
- fix leaderboard and school route prefixes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686a72a0bd988321815583abaa5d45d7